### PR TITLE
K8s filter contexts

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -792,6 +792,7 @@
         "detect_files": [],
         "detect_folders": [],
         "disabled": true,
+        "filter_contexts": [],
         "format": "[$symbol$context( \\($namespace\\))]($style) in ",
         "style": "cyan bold",
         "symbol": "☸ ",
@@ -3509,6 +3510,13 @@
           }
         },
         "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "filter_contexts": {
           "default": [],
           "type": "array",
           "items": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2176,6 +2176,7 @@ case the module will only be active in directories that match those conditions.
 | `style`             | `"cyan bold"`                                      | The style for the module.                                             |
 | `context_aliases`   |                                                    | Table of context aliases to display.                                  |
 | `user_aliases`      |                                                    | Table of user aliases to display.                                     |
+| `filter_contexts`   | `[]`                                               | List of context names to be ignored.                                  |
 | `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
 | `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
 | `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -18,6 +18,7 @@ pub struct KubernetesConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub filter_contexts: Vec<&'a str>,
 }
 
 impl<'a> Default for KubernetesConfig<'a> {
@@ -32,6 +33,7 @@ impl<'a> Default for KubernetesConfig<'a> {
             detect_extensions: vec![],
             detect_files: vec![],
             detect_folders: vec![],
+            filter_contexts: vec![],
         }
     }
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -144,6 +144,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let kube_ctx = env::split_paths(&kube_cfg).find_map(get_kube_context)?;
 
+    if config.filter_contexts.contains(&kube_ctx.as_str()) {
+        return None;
+    }
+
     let ctx_components: Vec<Option<KubeCtxComponents>> = env::split_paths(&kube_cfg)
         .map(|filename| get_kube_ctx_component(filename, kube_ctx.clone()))
         .collect();
@@ -953,6 +957,45 @@ users: []
 
         let expected = Some("☸ test_user test_namespace".to_string());
         assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_ctx_filter_simple() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let filename = dir.path().join("config");
+
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: test_cluster
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                filter_contexts = ["test_context"]
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+
         dir.close()
     }
 }


### PR DESCRIPTION
Allow filtering of kubernetes context names

#### Description
This change should allow the user to specify a list of namespace names to be ignored via the variable `filter_contexts`. Any context that matches a name on this list will be ignored. 

#### Motivation and Context
This is to allow the user to ignore regular local contexts like `docker-desktop`. Basically, I want to have a way to ignore the default context I have.

#### How Has This Been Tested?
Tested with `cargo test kubernetes`
- [x] I have tested using **MacOS**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
