### PR TITLE
feat(kubernetes): ignore contexts/namespaces

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -876,6 +876,9 @@
         "detect_folders": [],
         "disabled": true,
         "format": "[$symbol$context( \\($namespace\\))]($style) in ",
+        "ignore_combo": {},
+        "ignore_contexts": [],
+        "ignore_namespaces": [],
         "style": "cyan bold",
         "symbol": "☸ ",
         "user_aliases": {}
@@ -3858,6 +3861,30 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "ignore_contexts": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_namespaces": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore_combo": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2390,6 +2390,10 @@ case the module will only be active in directories that match those conditions.
 | `style`             | `'cyan bold'`                                      | The style for the module.                                             |
 | `context_aliases`   | `{}`                                               | Table of context aliases to display.                                  |
 | `user_aliases`      | `{}`                                               | Table of user aliases to display.                                     |
+| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                  |
+| `ignore_namespaces` | `[]`                                               | List of namespace names to be ignored.                                |
+| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                  |
+| `ignore_combo`      | `{}`                                               | Table of context/namespace names to ignore.                           |
 | `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
 | `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
 | `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2383,21 +2383,21 @@ case the module will only be active in directories that match those conditions.
 
 ### Options
 
-| Option              | Default                                            | Description                                                           |
-| ------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
-| `symbol`            | `'☸ '`                                             | A format string representing the symbol displayed before the Cluster. |
-| `format`            | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.                                            |
-| `style`             | `'cyan bold'`                                      | The style for the module.                                             |
-| `context_aliases`   | `{}`                                               | Table of context aliases to display.                                  |
-| `user_aliases`      | `{}`                                               | Table of user aliases to display.                                     |
-| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                  |
-| `ignore_namespaces` | `[]`                                               | List of namespace names to be ignored.                                |
-| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                  |
-| `ignore_combo`      | `{}`                                               | Table of context/namespace names to ignore.                           |
-| `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
-| `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
-| `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |
-| `disabled`          | `true`                                             | Disables the `kubernetes` module.                                     |
+| Option              | Default                                            | Description                                                                                                           |
+| ------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `symbol`            | `'☸ '`                                             | A format string representing the symbol displayed before the Cluster.                                                 |
+| `format`            | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.                                                                                            |
+| `style`             | `'cyan bold'`                                      | The style for the module.                                                                                             |
+| `context_aliases`   | `{}`                                               | Table of context aliases to display.                                                                                  |
+| `user_aliases`      | `{}`                                               | Table of user aliases to display.                                                                                     |
+| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                                                                  |
+| `ignore_namespaces` | `[]`                                               | List of namespace names to be ignored.                                                                                |
+| `ignore_contexts`   | `[]`                                               | List of context names to be ignored.                                                                                  |
+| `ignore_combo`      | `{}`                                               | Table of context/namespace names to ignore. Add the `""` namespace if you want to ignore when no namespace is defined |
+| `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                                                                          |
+| `detect_files`      | `[]`                                               | Which filenames should trigger this module.                                                                           |
+| `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                                                                            |
+| `disabled`          | `true`                                             | Disables the `kubernetes` module.                                                                                     |
 
 ### Variables
 
@@ -2427,6 +2427,8 @@ disabled = false
 [kubernetes.user_aliases]
 'dev.local.cluster.k8s' = 'dev'
 'root/.*' = 'root'
+[kubernetes.ignore_combo]
+docker-desktop = ["default", ""]
 ```
 
 Only show the module in directories that contain a `k8s` file.

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -18,6 +18,9 @@ pub struct KubernetesConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub ignore_contexts: Vec<&'a str>,
+    pub ignore_namespaces: Vec<&'a str>,
+    pub ignore_combo: HashMap<String, Vec<&'a str>>,
 }
 
 impl<'a> Default for KubernetesConfig<'a> {
@@ -32,6 +35,9 @@ impl<'a> Default for KubernetesConfig<'a> {
             detect_extensions: vec![],
             detect_files: vec![],
             detect_folders: vec![],
+            ignore_contexts: vec![],
+            ignore_namespaces: vec![],
+            ignore_combo: HashMap::new(),
         }
     }
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -141,6 +141,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let kube_ctx = env::split_paths(&kube_cfg).find_map(get_kube_context)?;
 
+    if config.ignore_contexts.contains(&kube_ctx.as_str()) {
+        return None
+    }
+
     let ctx_components: Vec<KubeCtxComponents> = env::split_paths(&kube_cfg)
         .filter_map(|filename| get_kube_ctx_component(filename, &kube_ctx))
         .collect();

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -145,6 +145,23 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .filter_map(|filename| get_kube_ctx_component(filename, &kube_ctx))
         .collect();
 
+    for ctx_component in ctx_components.iter() {
+        let kube_namespace = match ctx_component.namespace.clone() { // TODO: not clone it
+            Some(val) => val,
+            _ => String::from(""),
+        };
+
+        let kube_namespace_str = kube_namespace.as_str();
+        if config.ignore_namespaces.contains(&kube_namespace_str) {
+            return None;
+        }
+
+        match config.ignore_combo.get(&kube_ctx) {
+            Some(list) => if list.contains(&kube_namespace_str) { return None; },
+            None => (),
+        }
+    }
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -930,6 +947,167 @@ users: []
 
         let expected = Some("☸ test_user test_namespace".to_string());
         assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_ctx_ignore_simple() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let filename = dir.path().join("config");
+
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: test_cluster
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                ignore_contexts = ["test_context"]
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_combo_ignore_with_namespace() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let filename = dir.path().join("config");
+
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: test_cluster
+      user: test_user
+      namespace: test_namespace
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                ignore_combo = { test_context = ["test_namespace"] }
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_combo_ignore_without_namespace() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let filename = dir.path().join("config");
+
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: test_cluster
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                ignore_combo = { test_context = ["test_namespace"] }
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "{} in ",
+            Color::Cyan.bold().paint("☸ test_context")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_combo_ignore_no_namespace() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let filename = dir.path().join("config");
+
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: test_cluster
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                ignore_combo = { test_context = [""] }
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+
         dir.close()
     }
 }


### PR DESCRIPTION
#### Description
Allow the user to hide k8s config based on context and/or namespace names

#### Motivation and Context
**Why is this change required?**: Because I don't want to see `docker-desktop` as my context all the time since it's my default one. But when I'm using the non-default namespaces, then I want to see it.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
